### PR TITLE
v0.2.0 Update API key request signed message format

### DIFF
--- a/__tests__/api-keys.test.ts
+++ b/__tests__/api-keys.test.ts
@@ -16,7 +16,7 @@ describe('API Keys Module', () => {
     const web3 = new Web3();
     const account: EthereumAccount = web3.eth.accounts.wallet.create(1)[0];
     const client = new DydxClient('https://example.com', { web3 });
-    await client.keys.getApiKeys(account.address);
+    await client.apiKeys.getApiKeys(account.address);
 
     expect(axios).toHaveBeenCalledTimes(1);
     expect(axios).toHaveBeenCalledWith({

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -5,7 +5,7 @@ describe('DydxClient', () => {
   it('has separate modules', () => {
     const client = new DydxClient('https://example.com');
     expect(client.eth).toBeTruthy();
-    expect(client.keys).toBeTruthy();
+    expect(client.apiKeys).toBeTruthy();
     expect(client.onboarding).toBeTruthy();
     expect(client.private).toBeTruthy();
     expect(client.public).toBeTruthy();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v3-client",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v3-client",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Trading client library for the new dYdX system (v3 API)",
   "main": "build/src/index.js",
   "scripts": {

--- a/src/dydx-client.ts
+++ b/src/dydx-client.ts
@@ -3,8 +3,8 @@ import {
 } from '@dydxprotocol/starkex-lib';
 import Web3 from 'web3';
 
+import ApiKeys from './modules/api-keys';
 import Eth from './modules/eth';
-import Keys from './modules/keys';
 import Onboarding from './modules/onboarding';
 import Private from './modules/private';
 import Public from './modules/public';
@@ -31,7 +31,7 @@ export default class DydxClient {
   // Modules. Except for `public`, these are created on-demand.
   private readonly _public: Public;
   private _private?: Private;
-  private _keys?: Keys;
+  private _apiKeys?: ApiKeys;
   private _onboarding?: Onboarding;
   private _eth?: Eth;
 
@@ -88,17 +88,17 @@ export default class DydxClient {
   /**
    * Get the keys module, used for managing API keys. Requires Ethereum key auth.
    */
-  get keys(): Keys {
-    if (!this._keys) {
+  get apiKeys(): ApiKeys {
+    if (!this._apiKeys) {
       if (this.signOffChainAction) {
-        this._keys = new Keys(this.host, this.signOffChainAction);
+        this._apiKeys = new ApiKeys(this.host, this.signOffChainAction);
       } else {
         return notSupported(
           'API key endpoints are not supported since neither web3 nor web3Provider was provided',
-        ) as Keys;
+        ) as ApiKeys;
       }
     }
-    return this._keys;
+    return this._apiKeys;
   }
 
   /**

--- a/src/lib/eth-validation/actions.ts
+++ b/src/lib/eth-validation/actions.ts
@@ -16,10 +16,9 @@ export function generateApiKeyAction({
   method: ApiMethod,
   data?: {},
 }): string {
-  // TODO: The signed data should be consistent with the other private endpoints.
   return (
-    (_.isEmpty(data) ? '' : JSON.stringify(data)) +
+    method +
     requestPath +
-    method
+    (_.isEmpty(data) ? '' : JSON.stringify(data))
   );
 }

--- a/src/modules/api-keys.ts
+++ b/src/modules/api-keys.ts
@@ -12,7 +12,7 @@ import {
 } from '../types';
 import { SignOffChainAction } from './sign-off-chain-action';
 
-export default class Keys {
+export default class ApiKeys {
   readonly host: string;
   readonly signOffChainAction: SignOffChainAction;
 


### PR DESCRIPTION
* Update the format of the message signed for API key requests, to be more intuitive and similar to the other private requests. This is already reflected in the v3 docs, and not specified by the proposals. (**This is a breaking change, needs to be synchronized across librarian, clients, frontend, users**)
* Rename keys module to apiKeys