### PR TITLE
Remove accountId as a param for historical funding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v3-client",
-  "version": "1.0.20",
+  "version": "1.0.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v3-client",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "Trading client library for the new dYdX system (v3 API)",
   "main": "build/src/index.js",
   "scripts": {

--- a/src/modules/private.ts
+++ b/src/modules/private.ts
@@ -687,14 +687,12 @@ export default class Private {
    * @description get historical pnl ticks for an account between certain times
    *
    * @param {
-   * @account being checked
    * @createdBeforeOrAt latest historical pnl tick being returned
    * @createdOnOrAfter earliest historical pnl tick being returned
    * }
    */
   getHistoricalPnl(
     params: {
-      accountId: string,
       createdBeforeOrAt?: ISO8601,
       createdOnOrAfter?: ISO8601,
     },


### PR DESCRIPTION
Not needed anymore