### PR TITLE
Update types for account and position response objects

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -63,10 +63,13 @@ export enum CandleResolution {
 }
 
 export enum OrderType {
+  MARKET = 'MARKET',
   LIMIT = 'LIMIT',
   STOP = 'STOP',
   TRAILING_STOP = 'TRAILING_STOP',
   TAKE_PROFIT = 'TAKE_PROFIT',
+  LIQUIDATION = 'LIQUIDATION',
+  LIQUIDATED = 'LIQUIDATED',
 }
 
 export enum TimeInForce {
@@ -274,7 +277,18 @@ export interface FillResponseObject {
 
 export interface UserResponseObject {
   ethereumAddress: string;
+  isRegistered: string;
+  email: string;
+  username: string;
+  referredByAffiliateLink?: string;
+  makerFeeRate: string;
+  takerFeeRate: string;
+  makerVolume30D: string;
+  takerVolume30D: string;
+  fees30D: string;
   userData: string;
+  dydxTokenBalance: string;
+  stakedDydxTokenBalance: string;
 }
 
 export interface AccountResponseObject {

--- a/src/types.ts
+++ b/src/types.ts
@@ -254,6 +254,9 @@ export interface PositionResponseObject {
   realizedPnl?: string;
   createdAt: ISO8601;
   closedAt?: ISO8601;
+  sumOpen: string;
+  sumClose: string;
+  netFunding: string;
 }
 
 export interface FillResponseObject {
@@ -283,6 +286,8 @@ export interface AccountResponseObject {
   pendingWithdrawals: string,
   openPositions: PositionsMap,
   id: string;
+  accountNumber: string;
+  quoteBalance: string;
 }
 
 export interface TransferResponseObject {


### PR DESCRIPTION
Update type definitions according to currently available documentation for:
- `OrderType` enum
- `PositionResponseObject`
- `AccountResponseObject`
- `UserResponseObject` 