### PR TITLE
v1.5.0 update ConfigResponseObject [BAC-1818]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v3-client",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v3-client",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Trading client library for the new dYdX system (v3 API)",
   "main": "build/src/index.js",
   "scripts": {

--- a/src/modules/public.ts
+++ b/src/modules/public.ts
@@ -286,8 +286,9 @@ export default class Public {
   }
 
   /**
-   * @description get any globally-defined variables from the server not associated with any
-   * particular market or account.
+   * @description  get global config variables for the exchange as a whole.
+   * This includes (but is not limited to) details on the exchange, including addresses,
+   * fees, transfers, and rate limits.
    */
   async getConfig(): Promise<ConfigResponseObject> {
     return this.get('config', {});

--- a/src/types.ts
+++ b/src/types.ts
@@ -383,6 +383,25 @@ export interface ConfigResponseObject {
   exchangeAddress: string;
   maxExpectedBatchLengthMinutes: string;
   maxFastWithdrawalAmount: string;
+  cancelOrderRateLimiting: CancelOrderRateLimiting;
+  placeOrderRateLimiting: PlaceOrderRateLimiting;
+}
+
+export interface CancelOrderRateLimiting {
+  maxPointsMulti: number;
+  maxPointsSingle: number;
+  windowSecMulti: number;
+  windowSecSingle: number;
+}
+
+export interface PlaceOrderRateLimiting {
+  maxPoints: number;
+  windowSec: number;
+  targetNotional: number;
+  minLimitConsumption: number;
+  minMarketConsumption: number;
+  minTriggerableConsumption: number;
+  maxOrderConsumption: number;
 }
 
 export interface FastWithdrawalsResponseObject {


### PR DESCRIPTION
We updated the [v3/config](https://docs.dydx.exchange/#get-global-configuration-variables) endpoint a while ago to surface rate limiting config variables, but I didn't update v3-client. So adding them in now