### PR TITLE
v1.6.9: [BAC-2410]: Add additional profile fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v3-client",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v3-client",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "Trading client library for the new dYdX system (v3 API)",
   "main": "build/src/index.js",
   "scripts": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -645,6 +645,7 @@ export interface ProfilePublicResponseObject {
   username: string | null,
   ethereumAddress: string | null,
   DYDXHoldings: string | null,
+  stakedDYDXHoldings: string | null,
   hedgiesHeld: number[],
   twitterHandle: string | null,
   tradingLeagues: {
@@ -654,6 +655,7 @@ export interface ProfilePublicResponseObject {
   tradingPnls: {
     absolutePnl30D: string | null,
     percentPnl30D: string | null,
+    volume30D: string,
   },
 }
 


### PR DESCRIPTION
Looks like there were a few fields that were missing in the profile endpoints that were in the design doc but not in the proposal:

DYDXHoldings should be split into two fields of dydxHoldings and stkdydxHoldings instead of showing the sum of staked and unstaked dydx

30DVolume  will be the sum of makerVolume30D and takerVolume30D in the users table. 