### PR TITLE
Fix getFundingPayments' return type

### DIFF
--- a/src/modules/private.ts
+++ b/src/modules/private.ts
@@ -779,7 +779,7 @@ export default class Private {
       effectiveBeforeOrAt?: ISO8601,
     },
     genericParams: GenericParams = {},
-  ): Promise<{ fundingPayments: FundingResponseObject }> {
+  ): Promise<{ fundingPayments: FundingResponseObject[] }> {
     return this._get(
       'funding',
       {


### PR DESCRIPTION
This PR fixes the return type of `getFundingPayments`, which returns a list of funding payments and not just a single one.