### PR TITLE
fix: add hedgiesHeld to UserResponseObject type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -362,6 +362,7 @@ export interface UserResponseObject {
   isRegistered: boolean;
   email: string | null;
   username: string | null;
+  publicId: string;
   userData: {};
   makerFeeRate: string | null;
   takerFeeRate: string | null;
@@ -373,7 +374,9 @@ export interface UserResponseObject {
   isSharingAddress: boolean | null;
   dydxTokenBalance: string;
   stakedDydxTokenBalance: string;
+  activeStakedDydxTokenBalance: string;
   isEmailVerified: boolean;
+  hedgiesHeld: number[];
   country: ISO31661ALPHA2 | null;
   languageCode: ISO6391 | null;
 }


### PR DESCRIPTION
@jiajames working on trading stats platform, came across missing response fields in UserResponseObject type "hedgiesHeld" from [spec](https://dydxprotocol.github.io/v3-teacher/#response-9) and others not in spec but returned in object.